### PR TITLE
Class alias from Varien_Profiler to Magento_Profiler for Magento 1

### DIFF
--- a/src/lib/Magento/Profiler.php
+++ b/src/lib/Magento/Profiler.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * Class Magento_Profiler is an alias for Varien_Profiler for back-porting to Magento 1
+ */
+class_alias('Varien_Profiler', 'Magento_Profiler');


### PR DESCRIPTION
Problem was that Magento 1 does not have an implementation of Magento_Profiler, because this is a Magento 2 class. Added a class alias as simplest way to perform back-port.

This relates to issue 7 (https://github.com/techdivision/TechDivision_MagentoUnitTesting/issues/7)
