### PR TITLE
Move /app/bootstrap.php and /app/autoload.php to /dev/tests/integrati…

### DIFF
--- a/src/dev/tests/integration/framework/autoloadCore.php
+++ b/src/dev/tests/integration/framework/autoloadCore.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * NOTICE OF LICENSE
  *
@@ -20,7 +19,7 @@
  * @since      Class available since Release 0.1.0
  * @author     TechDivision Core Team <core@techdivision.com>
  */
-require_once __DIR__ . '/../lib/Magento/Autoload/IncludePath.php';
+require_once BP . '/lib/Magento/Autoload/IncludePath.php';
 if (class_exists('Magento\\Autoload\\IncludePath', false)) {
     spl_autoload_register('Magento\\Autoload\\IncludePath::load', true, true);
 } else {

--- a/src/dev/tests/integration/framework/bootstrap.php
+++ b/src/dev/tests/integration/framework/bootstrap.php
@@ -25,7 +25,7 @@
  * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  */
 
-require_once __DIR__ . '/../../../../app/bootstrap.php';
+require_once __DIR__ . '/bootstrapCore.php';
 require_once __DIR__ . '/../../static/testsuite/Utility/Classes.php';
 
 Utility_Files::init(new Utility_Files(realpath(__DIR__ . '/../../../..')));

--- a/src/dev/tests/integration/framework/bootstrapCore.php
+++ b/src/dev/tests/integration/framework/bootstrapCore.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * NOTICE OF LICENSE
  *
@@ -36,11 +35,11 @@ umask(0);
  * Constants definition
  */
 define('DS', DIRECTORY_SEPARATOR);
-define('BP', dirname(__DIR__));
+define('BP', dirname(__DIR__ . '/../../../../..'));
 
 /**
  * Require necessary files
  */
 require_once BP . '/app/code/core/Mage/Core/functions.php';
 require_once BP . '/app/Mage.php';
-require_once BP . '/app/autoload.php';
+require_once __DIR__ . '/autoloadCore.php';


### PR DESCRIPTION
…on/framework/ and adapt include paths, because the /app/bootstrap.php conflicts with the magento core /app/bootstrap.php introduced in 1.14.2.
