### PR TITLE
[FIX] Fixed issue that when using this module, installation could fai…

### DIFF
--- a/src/app/code/community/Mage/Install/Model/Installer/Db/Mysql4.php
+++ b/src/app/code/community/Mage/Install/Model/Installer/Db/Mysql4.php
@@ -43,8 +43,8 @@ class Mage_Install_Model_Installer_Db_Mysql4 extends Mage_Install_Model_Installe
     public function supportEngine()
     {
         $variables  = $this->_getConnection()
-            ->fetchPairs('SHOW VARIABLES');
-        return (!isset($variables['have_innodb']) || $variables['have_innodb'] != 'YES') ? false : true;
+            ->fetchPairs('SHOW ENGINES');
+        return isset($variables['InnoDB']) && ($variables['InnoDB'] == 'DEFAULT' || $variables['InnoDB'] == 'YES');
     }
     
     /**


### PR DESCRIPTION
…l on newer mysql versions
Due to the codepool rewrite of Mage_Install_Model_Installer_Db_Mysql4 some old code was still present that would fail on MySQL v5.6 or newer. The method Mage_Install_Model_Installer_Db_Mysql4::supportEngine() was updated to comply with Magento 1.9.2.4 which is fail safe over all MySQL versions from 5.5 upwards.
