### PR TITLE
Fixed that gitignore exceptions would not work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,6 @@
 /build.properties
 /build
 /output
-/src/lib
+/src/lib/*
 !/src/lib/Magento
 !/src/lib/PHPUnit


### PR DESCRIPTION
By excluding the whole `src/lib` folder, the exceptions for `src/lib/Magento` and `src/lib/PHPUnit` would not work. For exceptions (aka unignores) to work, the parent folder may not be ignored but only its content may.